### PR TITLE
Fix #1 - Introduce 4 new keep-alive related configurations to support socket keep-alive when Rserve deployed behind proxy/firewall/load-balancer

### DIFF
--- a/src/RSserver.h
+++ b/src/RSserver.h
@@ -36,7 +36,7 @@ typedef struct server {
 #define LSM_IP_LOCAL 1 /* bind to loopback address only */
 #define LSM_IPV6     2 /* use IPv6 (if available) */
 
-server_t *create_server(int port, const char *localSocketName, int localSocketMode, int flags);
+server_t *create_server(int port, int socketKeepAlive, int socketKeepAliveTime, int socketKeepAliveInterval, int socketKeepAliveProbes, const char *localSocketName, int localSocketMode, int flags);
 int add_server(server_t *srv);
 int rm_server(server_t *srv);
 

--- a/src/http.c
+++ b/src/http.c
@@ -879,7 +879,7 @@ static void HTTP_connected(void *parg) {
 }
 
 server_t *create_HTTP_server(int port, int flags) {
-	server_t *srv = create_server(port, 0, 0, flags);
+	server_t *srv = create_server(port, 0, 0, 0, 0, 0, 0, flags);
 #ifdef RSERV_DEBUG
 	fprintf(stderr, "create_HTTP_server(port = %d, flags=0x%x)\n", port, flags);
 #endif

--- a/src/other/RSpool.c
+++ b/src/other/RSpool.c
@@ -354,7 +354,7 @@ int main(int argc, char **argv) {
 		RSargv[j] = 0;
 	}
 
-	srv = create_server(port, 0, 0, 0);
+	srv = create_server(port, 0, 0, 0, 0, 0, 0, 0);
 	if (!srv) return 0;
 
 	if (max_pool < workers) max_pool = workers;

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -712,7 +712,7 @@ static int  WS_recv_data(args_t *arg, void *buf, rlen_t read_len) {
 }
 
 server_t *create_WS_server(int port, int flags) {
-	server_t *srv = create_server(port, 0, 0, flags);
+	server_t *srv = create_server(port, 0, 0, 0, 0, 0, 0, flags);
 	if (srv) {
 		srv->connected = WS_connected;
 		srv->send_resp = WS_send_resp;


### PR DESCRIPTION
- keep-alive = when set to enabled, socket option will be set with
  system wide settings for Time, Interval & Probes.
- keep-alive-time - time in seconds to override the system wide value
  for this process
- keep-alive-interval - retry interval in seconds to override the system
  wide value for this process
- keep-alive-probes - number of probes to override the system wide value
  for this process
