### PR TITLE
fixed bug

### DIFF
--- a/src/client/cxx/Rconnection.cc
+++ b/src/client/cxx/Rconnection.cc
@@ -140,7 +140,7 @@ Rmessage::Rmessage(int cmd, const void *buf, int dlen, int raw_data) {
     head.cmd=cmd;
     head.len=len;
     data=(char*)malloc(len);
-    memcpy(data, (raw_data)?buf:((char*)buf+4), dlen);
+    memcpy((void*)((raw_data) ? data : data + 4), buf, dlen);
     if (!raw_data)
         *((int*)data)=itop(SET_PAR(DT_BYTESTREAM,dlen));  
     complete=1;


### PR DESCRIPTION
one must not start in a higher addr to copy, but increment the target to leave space for the special header
