### PR TITLE
updated DESCRIPTION version to latest NEWS - 1.8.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rserve
-Version: 1.7
+Version: 1.8.4
 Title: Binary R server
 Author: Simon Urbanek <Simon.Urbanek@r-project.org>
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>


### PR DESCRIPTION
Current github file has 1.7 version, while on cran there is 1.7-3. I would like to setup drat for recent Rserve version, according the NEWS file now is 1.8.3 or 1.8.4 dev.
Currently due to low version in gh repo (1.7) the package installed from github/drat is likely to be overwritten by "update" from CRAN. This change will reflect reality and allows better integration in development.