### PR TITLE
renamed default config.file in run.Rserve, solved #48

### DIFF
--- a/R/conn.R
+++ b/R/conn.R
@@ -36,8 +36,9 @@ Rserve <- function(debug=FALSE, port, args=NULL, quote=(length(args) > 1), wait,
   invisible(system(cmd, wait=wait, ...))
 }
 
-run.Rserve <- function(..., config.file="/etc/Rserve.conf") {
+run.Rserve <- function(..., config.file="/etc/Rserv.conf") {
   if (is.null(run_Rserve)) stop("Runnig inside an embedded Rserve instance - starting Rserve recursively is not supported")
+  if(identical(unname(config.file), "/etc/Rserve.conf")) config.file = "/etc/Rserv.conf"
   .Call(run_Rserve, as.character(config.file), sapply(list(...), as.character))
 }
 

--- a/man/run.Rserve.Rd
+++ b/man/run.Rserve.Rd
@@ -13,7 +13,7 @@
   interfere with the prepation of \code{Rserve}.
 }
 \usage{
-run.Rserve(..., config.file = "/etc/Rserve.conf")
+run.Rserve(..., config.file = "/etc/Rserv.conf")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{


### PR DESCRIPTION
~~Backward compatible~~ fix for #48.
Just realized that potentially existing `Rserve.conf` file should be renamed too, so fix is not really backward compatible. I can add something like `if(config.file=="Rserv.conf" && file.exists("Rserve.conf")) warning(...)` when old file is detected, if you are going to accept fix.