### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,9 @@
 PKG_CPPFLAGS=-DRSERVE_PKG -DWin32 -I. -Iinclude -Iinclude/Win32
-PKG_LIBS=-lssl -lcrypto -lws2_32 -lcrypt32 -lz
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS=-lssl -lcrypto -lws2_32 -lcrypt32 -lz
+else
+  PKG_LIBS=$(shell pkg-config --libs openssl)
+endif
 
 all: $(SHLIB) server
 #	$(MAKE) client


### PR DESCRIPTION
This will get the libraries to link on Windows from pkg-config, when available.